### PR TITLE
Support option query

### DIFF
--- a/store4s/src/main/scala/store4s/Query.scala
+++ b/store4s/src/main/scala/store4s/Query.scala
@@ -82,9 +82,11 @@ object Query {
     }.toList
 
     def isCaseClass(t: Type) = {
-      // The isCaseClass method on ClassSymbol still has some problems, use a workaround here
+      // isCaseClass may not work correctly if not initialized first,
+      // which may cause error in nested Entity or array of Entities
       // https://stackoverflow.com/questions/12377046
-      t.baseClasses.exists(_.name.toString() == "Product")
+      { t.typeSymbol.asClass.typeSignature }
+      t.typeSymbol.asClass.isCaseClass
     }
 
     def makeTrait(t: Type, outerName: String) = {

--- a/store4s/src/test/scala/store4s/QuerySpec.scala
+++ b/store4s/src/test/scala/store4s/QuerySpec.scala
@@ -3,6 +3,7 @@ package store4s
 import com.google.cloud.Timestamp
 import com.google.cloud.datastore.Entity
 import com.google.cloud.datastore.KeyFactory
+import com.google.cloud.datastore.NullValue
 import com.google.cloud.datastore.QueryResults
 import com.google.cloud.datastore.StructuredQuery.CompositeFilter
 import com.google.cloud.datastore.StructuredQuery.OrderBy
@@ -140,6 +141,36 @@ class QuerySpec extends AnyFlatSpec with MockFactory {
       .build()
 
     assert(qG == qS)
+  }
+
+  it should "support nullable value" in {
+    val qGNull = GQuery
+      .newEntityQueryBuilder()
+      .setKind("User")
+      .setFilter(
+        PropertyFilter.eq("name", NullValue.of())
+      )
+      .build()
+    val qGSome = GQuery
+      .newEntityQueryBuilder()
+      .setKind("User")
+      .setFilter(
+        PropertyFilter.eq("name", "Sakura Minamoto")
+      )
+      .build()
+
+    case class User(name: Option[String])
+    val qSNull = Query[User]
+      .filter(_.name == None)
+      .builder()
+      .build()
+    val qSSome = Query[User]
+      .filter(_.name == Some("Sakura Minamoto"))
+      .builder()
+      .build()
+
+    assert(qGNull == qSNull)
+    assert(qGSome == qSSome)
   }
 
   it should "decode QueryResults" in {

--- a/store4sV1/src/main/scala/store4s/v1/Query.scala
+++ b/store4sV1/src/main/scala/store4s/v1/Query.scala
@@ -102,9 +102,11 @@ object Query {
     }.toList
 
     def isCaseClass(t: Type) = {
-      // The isCaseClass method on ClassSymbol still has some problems, use a workaround here
+      // isCaseClass may not work correctly if not initialized first,
+      // which may cause error in nested Entity or array of Entities
       // https://stackoverflow.com/questions/12377046
-      t.baseClasses.exists(_.name.toString() == "Product")
+      { t.typeSymbol.asClass.typeSignature }
+      t.typeSymbol.asClass.isCaseClass
     }
 
     def makeTrait(t: Type, outerName: String) = {

--- a/store4sV1/src/test/scala/store4s/v1/QuerySpec.scala
+++ b/store4sV1/src/test/scala/store4s/v1/QuerySpec.scala
@@ -15,6 +15,7 @@ import com.google.datastore.v1.Value
 import com.google.datastore.v1.client.DatastoreOptions
 import com.google.datastore.v1.{Query => GQuery}
 import com.google.protobuf.Int32Value
+import com.google.protobuf.NullValue
 import com.google.protobuf.Timestamp
 import org.scalatest.flatspec.AnyFlatSpec
 
@@ -242,6 +243,43 @@ class QuerySpec extends AnyFlatSpec {
       .build()
 
     assert(qG == qS)
+  }
+
+  it should "support nullable value" in {
+    def qG(v: Value) = GQuery
+      .newBuilder()
+      .addKind(KindExpression.newBuilder().setName("User"))
+      .setFilter(
+        Filter
+          .newBuilder()
+          .setPropertyFilter(
+            PropertyFilter
+              .newBuilder()
+              .setOp(Operator.EQUAL)
+              .setProperty(
+                PropertyReference.newBuilder().setName("name")
+              )
+              .setValue(v)
+          )
+      )
+      .build()
+    val qGNull =
+      qG(Value.newBuilder().setNullValue(NullValue.NULL_VALUE).build())
+    val qGSome =
+      qG(Value.newBuilder().setStringValue("Sakura Minamoto").build())
+
+    case class User(name: Option[String])
+    val qSNull = Query[User]
+      .filter(_.name == None)
+      .builder()
+      .build()
+    val qSSome = Query[User]
+      .filter(_.name == Some("Sakura Minamoto"))
+      .builder()
+      .build()
+
+    assert(qGNull == qSNull)
+    assert(qGSome == qSSome)
   }
 
   it should "decode RunQueryResponse" in {


### PR DESCRIPTION
The old implementation of `isCaseClass` prevents the nullable filter in Query, e.g.
```scala
.filter(_.name == None)
```
or
```scala
.filter(_.name == Some("Tom"))
```
Change the implementation and add test for the above cases.